### PR TITLE
redirect learn more button to wordpress

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
           <p>We&#8217;re improving on technology pioneered by social networks, crowdfunding platforms, and local forums. <strong>But it&#8217;s not a tech company&#8212;it&#8217;s a platform cooperative, and if you&#8217;re on it, you own it.</strong></p>
         </div>
         <div class="text-center border-t border-zinc-900">
-          <a class="py-4 w-full h-full block font-semibold text-xl hover:bg-zinc-600 active:bg-zinc-800" href="https://opencollective.com/commonplace" target="_blank">
+          <a class="py-4 w-full h-full block font-semibold text-xl hover:bg-zinc-600 active:bg-zinc-800" href="https://commonplacecooperative.wordpress.com/" target="_blank">
             Learn More!
           </a>
         </div>


### PR DESCRIPTION
I changed the redirect to the wordpress site rather than open collective. 